### PR TITLE
Fixed gcc multi os directory command line argument syntax

### DIFF
--- a/arm-none-eabi-binutils.rb
+++ b/arm-none-eabi-binutils.rb
@@ -29,7 +29,7 @@ class ArmNoneEabiBinutils < Formula
 
 
         # Do not install libiberty.a, as it may conflict with host file
-        multios = `gcc --print-multi-os-dir`.chomp
+        multios = `gcc --print-multi-os-directory`.chomp
         File.unlink "#{lib}/#{multios}/libiberty.a"
     end
   end

--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -17,7 +17,7 @@ class ArmNoneEabiGcc < Formula
   depends_on 'gmp'
   depends_on 'mpfr'
   depends_on 'libmpc'
-  depends_on 'ppl'
+  depends_on 'ppl10'
   depends_on 'cloog'
 
   depends_on 'arm-none-eabi-binutils'
@@ -56,7 +56,7 @@ class ArmNoneEabiGcc < Formula
 
     args << "--enable-languages=#{languages.join(',')}"
 
-    ['gmp', 'mpfr', 'ppl', 'cloog'].each do |dep|
+    ['gmp', 'mpfr', 'ppl10', 'cloog'].each do |dep|
       args << "--with-#{dep}=#{(Formula.factory dep).prefix}"
     end
 

--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -79,7 +79,7 @@ class ArmNoneEabiGcc < Formula
       system "make install"
 
       # Do not install libiberty.a, as it may conflict with host file
-      multios = `gcc --print-multi-os-dir`.chomp
+      multios = `gcc --print-multi-os-directory`.chomp
       File.unlink "#{lib}/#{multios}/libiberty.a"
     end
   end


### PR DESCRIPTION
Changed --print-multi-os-dir to --print-multi-os-dirrectory in both
formulae. Otherwise I get "clang: error: unsupported option '--print-multi-os-dir'" in gcc 4.2.1 with XCode 5.
